### PR TITLE
Add apt to dependencies in metadata.json

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -9,6 +9,10 @@
   "issues_url": "https://github.com/voxpupuli/puppet-nginx/issues",
   "dependencies": [
     {
+      "name": "puppetlabs/apt",
+      "version_requirement": ">= 7.2.0 < 8.0.0"
+    },
+    {
       "name": "puppetlabs/concat",
       "version_requirement": ">= 4.1.0 < 7.0.0"
     },


### PR DESCRIPTION
#### Pull Request (PR) description

Prior to this commit, apt was required in the fixutures but not in metadata.json. Version 7.2.0 was chosen as the lower bounds of the apt module version because that is when Debian 10 support was added.

#### This Pull Request (PR) fixes the following issues

Fixes #1374